### PR TITLE
Fix shard naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Add this to your application's `shard.yml`:
 
 ```yaml
 dependencies:
-  schemas:
+  schema:
     github: eliasjpr/schema-validation
 ```
 
 ## Usage
 
 ```crystal
-require "schemas"
+require "schema"
 ```
 
 ## Defining Self Validated Schemas

--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: schemas
+name: schema
 version: 0.1.0
 
 authors:


### PR DESCRIPTION
Just been trying this out on Amber and noticed the shard naming was incorrect preventing `require` from being able to find the entrypoint.